### PR TITLE
Change ctags regex to support TOC following

### DIFF
--- a/.ctags
+++ b/.ctags
@@ -2,11 +2,23 @@
 --langmap=plaintex:.tex
 --regex-plaintex=/\\label\{([^}]*)\}/\1/l,label/
 
---regex-plaintex=/\\section\{([^}]*)\}/\1/s,section/
---regex-plaintex=/\\subsection\{([^}]*)\}/\1/t,subsection/
---regex-plaintex=/\\subsubsection\{([^}]*)\}/\1/u,subsubsection/
---regex-plaintex=/\\cite\{([^}]*)\}/\1/c,citation/
-
---regex-plaintex=/\\section\*\{([^}]*)\}/\1/s,section/
---regex-plaintex=/\\subsection\*\{([^}]*)\}/\1/t,subsection/
---regex-plaintex=/\\subsubsection\*\{([^}]*)\}/\1/u,subsubsection/
+--regex-plaintex=/^\\tableofcontents/TABLE OF CONTENTS/s,toc/
+--regex-plaintex=/^\\frontmatter/FRONTMATTER/s,frontmatter/
+--regex-plaintex=/^\\mainmatter/MAINMATTER/s,mainmatter/
+--regex-plaintex=/^\\backmatter/BACKMATTER/s,backmatter/
+--regex-plaintex=/^\\bibliography\{/BIBLIOGRAPHY/s,bibliography/
+--regex-plaintex=/^\\part[[:space:]]*(\[[^]]*\])?[[:space:]]*\{([^}]+)\}/PART \2/s,part/
+--regex-plaintex=/^\\part[[:space:]]*\*[[:space:]]*\{([^}]+)\}/PART \1/s,part/
+--regex-plaintex=/^\\chapter[[:space:]]*(\[[^]]*\])?[[:space:]]*\{([^}]+)\}/CHAP \2/s,chapter/
+--regex-plaintex=/^\\chapter[[:space:]]*\*[[:space:]]*\{([^}]+)\}/CHAP \1/s,chapter/
+--regex-plaintex=/^\\section[[:space:]]*(\[[^]]*\])?[[:space:]]*\{([^}]+)\}/\. \2/s,section/
+--regex-plaintex=/^\\section[[:space:]]*\*[[:space:]]*\{([^}]+)\}/\. \1/s,section/
+--regex-plaintex=/^\\subsection[[:space:]]*(\[[^]]*\])?[[:space:]]*\{([^}]+)\}/\.\. \2/s,subsection/
+--regex-plaintex=/^\\subsection[[:space:]]*\*[[:space:]]*\{([^}]+)\}/\.\. \1/s,subsection/
+--regex-plaintex=/^\\subsubsection[[:space:]]*(\[[^]]*\])?[[:space:]]*\{([^}]+)\}/\.\.\. \2/s,subsubsection/
+--regex-plaintex=/^\\subsubsection[[:space:]]*\*[[:space:]]*\{([^}]+)\}/\.\.\. \1/s,subsubsection/
+--regex-plaintex=/^\\includegraphics[[:space:]]*(\[[^]]*\])?[[:space:]]*(\[[^]]*\])?[[:space:]]*\{([^}]+)\}/\3/g,graphic+listing/
+--regex-plaintex=/^\\lstinputlisting[[:space:]]*(\[[^]]*\])?[[:space:]]*(\[[^]]*\])?[[:space:]]*\{([^}]+)\}/\3/g,graphic+listing/
+--regex-plaintex=/\\label[[:space:]]*\{([^}]+)\}/\1/l,label/
+--regex-plaintex=/\\ref[[:space:]]*\{([^}]+)\}/\1/r,ref/
+--regex-plaintex=/\\pageref[[:space:]]*\{([^}]+)\}/\1/p,pageref/


### PR DESCRIPTION
I have edited ctags regex for supporting TOC following this https://github.com/majutsushi/tagbar/blob/master/doc/tagbar.txt

I think it can see the overview of the latex project more than previous `.ctags` file

The result is something like this, but I don't sure that it works for Thai.
![screenshot_2015-09-26_16-29-59](https://cloud.githubusercontent.com/assets/3647850/10116870/38cd7878-646d-11e5-96dd-165eb04773a9.png)

You can discuss or reject when you think it should not, or not supporting with Thai

Thank you
